### PR TITLE
chore: replace devspaces-samples/rest-http-example with che-samples/java-spring-petclinic

### DIFF
--- a/src/lib/try/TryOnline.svelte
+++ b/src/lib/try/TryOnline.svelte
@@ -68,7 +68,7 @@
     </TryTechnology>
 
 
-    <TryTechnology hrefLink='https://workspaces.openshift.com#https://github.com/devspaces-samples/rest-http-example/tree/devspaces-3.3-rhel-8&storageType=ephemeral'>
+    <TryTechnology hrefLink='https://workspaces.openshift.com#https://github.com/che-samples/java-spring-petclinic/tree/devfilev2&storageType=ephemeral'>
         <Spring size={70} color={$darkModeThemeEnabled ? 'currentColor' : "#6DB33F"}/>
     </TryTechnology>
 


### PR DESCRIPTION
Signed-off-by: Vitaliy Gulyy <vgulyy@redhat.com>

Replaces **rest-http-example** example with https://github.com/che-samples/java-spring-petclinic/tree/devfilev2

Solves https://github.com/eclipse/che/issues/21937
