### PR TITLE
Use latest UDI image

### DIFF
--- a/.devfile.yaml
+++ b/.devfile.yaml
@@ -6,7 +6,7 @@ attributes:
 components:
   - name: development-tooling
     container:
-      image: quay.io/devfile/universal-developer-image:ubi8-bf01a50
+      image: quay.io/devfile/universal-developer-image:latest
       memoryLimit: 4Gi
       cpuLimit: 1400m
       endpoints:


### PR DESCRIPTION
Use the latest universal developers image. In my testing for `podman build` using the che-website devfile, I encountered build errors that were resolved by updating the UDI. 