### PR TITLE
fix: using absolute URLs for the Meta Tags

### DIFF
--- a/src/routes/extend/index.svelte
+++ b/src/routes/extend/index.svelte
@@ -9,7 +9,7 @@ import Visualstudiocode from '@icons-pack/svelte-simple-icons/src/components/Vis
 
 	$pageTitle = "Extend";
   	$pageDescription = "Code, Build and Debug in your own browser by extending Eclipse Che.";
-  	$pageUrl = "/extend/";
+  	$pageUrl = "https://www.eclipse.org/che/extend/";
 
 	let cheSampleImage;
 

--- a/src/routes/features/index.svelte
+++ b/src/routes/features/index.svelte
@@ -10,7 +10,7 @@
 
 	$pageTitle = "Features";
   	$pageDescription = "Start coding in minutes, not days. Modern IDEs features are available in the browser and there is no need to locally install development tools.";
-  	$pageUrl = "/features/";
+  	$pageUrl = "https://www.eclipse.org/che/features/";
 
 	let shareDevfileImage;
 	let shareDevfileAltImage;

--- a/src/routes/getting-started/cloud/index.svelte
+++ b/src/routes/getting-started/cloud/index.svelte
@@ -6,7 +6,7 @@
 
 	$pageTitle = "Cloud";
   	$pageDescription = "Try Eclipse Che online.";
-  	$pageUrl = "/getting-started/cloud/";
+  	$pageUrl = "https://www.eclipse.org/che/getting-started/cloud/";
 	
 	onMount(() => {
 	darkModeThemeEnabled.subscribe(isEnabled => {

--- a/src/routes/getting-started/download/index.svelte
+++ b/src/routes/getting-started/download/index.svelte
@@ -6,7 +6,7 @@
 
 	$pageTitle = "Install";
   	$pageDescription = "Install it on your Kubernetes cluster.";
-  	$pageUrl = "/getting-started/download/";
+  	$pageUrl = "https://www.eclipse.org/che/getting-started/download/";
 	
 	onMount(() => {
 	darkModeThemeEnabled.subscribe(isEnabled => {

--- a/src/routes/getting-started/index.svelte
+++ b/src/routes/getting-started/index.svelte
@@ -6,7 +6,7 @@
 
 	$pageTitle = "Getting Started";
   	$pageDescription = "Try Eclipse Che online Or install it on your Kubernetes cluster.";
-  	$pageUrl = "/getting-started/";
+  	$pageUrl = "https://www.eclipse.org/che/getting-started/";
 	
 
 	onMount(() => {

--- a/src/routes/index.svelte
+++ b/src/routes/index.svelte
@@ -11,7 +11,7 @@
 
 	$pageTitle = 'Home';
 	$pageDescription = 'Run your favorite IDE on Kubernetes.';
-	$pageUrl = '/';
+	$pageUrl = 'https://www.eclipse.org/che/';
 
 	let ideImages = [];
 	const darkImages = [`${variables.imagesPath}/ide-code-dark.png`, `${variables.imagesPath}/ide-pycharm-dark.png`, `${variables.imagesPath}/ide-theia-dark.png`]

--- a/src/routes/technology/index.svelte
+++ b/src/routes/technology/index.svelte
@@ -6,7 +6,7 @@
 
 	$pageTitle = 'How it Works';
 	$pageDescription = 'A Closer Look at the High Level Architecture of Eclipse Che.';
-	$pageUrl = '/technology/';
+	$pageUrl = 'https://www.eclipse.org/che/technology/';
 
 	let highLevelImage;
 	let devfileToDevWorkspaceImage;


### PR DESCRIPTION
Signed-off-by: Ilya Buziuk <ibuziuk@redhat.com>

Fixing the build by using absolute URLs for meta tags. Previous version was introduced in https://github.com/eclipse-che/che-website/pull/75 does not pass the `yarn build` and fails with:

```
> Using @sveltejs/adapter-static
> 404 / (linked from /che/getting-started/)
    at file:///home/ibuziuk/git/che-website/node_modules/@sveltejs/kit/dist/chunks/index5.js:432:11
    at visit (file:///home/ibuziuk/git/che-website/node_modules/@sveltejs/kit/dist/chunks/index5.js:541:4)
    at Object.fn (file:///home/ibuziuk/git/che-website/node_modules/@sveltejs/kit/dist/chunks/index5.js:531:22)
    at dequeue (file:///home/ibuziuk/git/che-website/node_modules/@sveltejs/kit/dist/chunks/index5.js:111:42)
    at file:///home/ibuziuk/git/che-website/node_modules/@sveltejs/kit/dist/chunks/index5.js:120:7
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
error Command failed with exit code 1.
```