### PR TITLE
chore: update che-samples links

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,12 +7,12 @@ https://www.eclipse.org/che website mirror
 
 Use the factory url https://workspaces.openshift.com#https://github.com/eclipse/che-website
 
-This factory will start che and clone the repo che-website.
+This factory will start Che and clone the repo che-website.
 
-On the right side `My workspace` view, you can start to preview the website after installing all dependencies (launch task 1 and then task 2)
+You can start to preview the website after installing all dependencies (launch task 1) and start development mode (launch task 2).
 
-### Commi
-You can commit with Theia git view or the terminal (with the git container). Create a dedicated branch and a fork if you are not commiter.
+### Commit
+You can commit with the Git view or the terminal (with the git container). Create a dedicated branch and a fork if you are not committer.
 In any case, you will need to create a Pull Request.
 
 Note that before your contribution can be accepted by the project, you need to electronically sign the [Eclipse Contributor Agreement](https://github.com/eclipse/che/wiki/Eclipse-Contributor-Agreement) (ECA). 

--- a/src/lib/footer/PageFooter.svelte
+++ b/src/lib/footer/PageFooter.svelte
@@ -53,7 +53,7 @@ import { variables } from '$lib/variables';
   </div>
   <div class="bg-gray-100 dark:bg-gray-800 dark:text-gray-400">
     <div class="container mx-auto py-4 px-5 flex flex-wrap flex-col sm:flex-row">
-      <p class="text-gray-500 dark:text-gray-400 text-sm text-center sm:text-left">© 2022 Eclipse Che</p>
+      <p class="text-gray-500 dark:text-gray-400 text-sm text-center sm:text-left">© 2023 Eclipse Che</p>
       <span class="inline-flex sm:ml-auto sm:mt-0 mt-2 justify-center sm:justify-start">
         <a target="_blank" title="github" rel="noopener noreferrer" href="https://github.com/eclipse/che" class="w-8 h-5 text-gray-500 dark:text-gray-400"><Fa icon={faGithub} /></a>
         <a target="_blank" title="twitter" rel="noopener noreferrer" href="https://twitter.com/eclipse_che" class="w-8 h-5 text-gray-500 dark:text-gray-400"><Fa icon={faTwitter} /></a>

--- a/src/lib/try/TryOnline.svelte
+++ b/src/lib/try/TryOnline.svelte
@@ -38,28 +38,27 @@
   <div class="absolute inset-x-0 top-0 items-center justify-center hidden overflow-hidden md:flex md:inset-y-0">
   </div>
   <div class="relative grid gap-7 grid-cols-2 sm:grid-cols-3 lg:grid-cols-6 dark:text-gray-300 ">
-      <TryTechnology hrefLink='https://workspaces.openshift.com#https://github.com/devspaces-samples/vertx-http-example/tree/devspaces-3.3-rhel-8&storageType=ephemeral'>
+    <TryTechnology hrefLink='https://workspaces.openshift.com#https://github.com/devspaces-samples/vertx-http-example/tree/devspaces-3.3-rhel-8&storageType=ephemeral'>
         <Java size={70} color={$darkModeThemeEnabled ? 'currentColor' : '#007396'}  />
-      </TryTechnology>
+    </TryTechnology>
 
-      <TryTechnology hrefLink='https://workspaces.openshift.com#https://github.com/devspaces-samples/golang-health-check/tree/devspaces-3.3-rhel-8&storageType=ephemeral'>
+    <TryTechnology hrefLink='https://workspaces.openshift.com#https://github.com/devspaces-samples/golang-health-check/tree/devspaces-3.3-rhel-8&storageType=ephemeral'>
         <Go size={70} color={$darkModeThemeEnabled ? 'currentColor' : "#00ADD8"}/>
-      </TryTechnology>
+    </TryTechnology>
 
-      <TryTechnology hrefLink='https://workspaces.openshift.com#https://github.com/devspaces-samples/python-hello-world/tree/devspaces-3.3-rhel-8&storageType=ephemeral'>
+    <TryTechnology hrefLink='https://workspaces.openshift.com#https://github.com/devspaces-samples/python-hello-world/tree/devspaces-3.3-rhel-8&storageType=ephemeral'>
         <Python size={70} color={$darkModeThemeEnabled ? 'currentColor' : "#3776AB"}/>
     </TryTechnology>
 
-    <TryTechnology hrefLink='https://workspaces.openshift.com#https://github.com/che-samples/nodejs-react-redux/tree/devfilev2&storageType=ephemeral'>
+    <TryTechnology hrefLink='https://workspaces.openshift.com#https://github.com/che-samples/nodejs-react-redux&storageType=ephemeral'>
         <ReactJs size={70} color={$darkModeThemeEnabled ? 'currentColor' : "#61DAFB"}/>
     </TryTechnology>
-
 
     <TryTechnology hrefLink='https://workspaces.openshift.com#https://github.com/devspaces-samples/dotnet-web-simple/tree/devspaces-3.3-rhel-8&storageType=ephemeral'>
         <DotNet size={70}  color={$darkModeThemeEnabled ? 'currentColor' : "#512BD4"}/>
     </TryTechnology>
 
-    <TryTechnology hrefLink='https://workspaces.openshift.com#https://github.com/che-samples/helloworld-rust/tree/devfilev2&storageType=ephemeral'>
+    <TryTechnology hrefLink='https://workspaces.openshift.com#https://github.com/che-samples/helloworld-rust&storageType=ephemeral'>
         <Rust size={70} color={$darkModeThemeEnabled ? 'currentColor' : "#000000"}/>
     </TryTechnology>
 
@@ -67,12 +66,11 @@
         <Quarkus size={70}  color={$darkModeThemeEnabled ? 'currentColor' : "#00ADD8"}/>
     </TryTechnology>
 
-
-    <TryTechnology hrefLink='https://workspaces.openshift.com#https://github.com/che-samples/java-spring-petclinic/tree/devfilev2&storageType=ephemeral'>
+    <TryTechnology hrefLink='https://workspaces.openshift.com#https://github.com/che-samples/java-spring-petclinic&storageType=ephemeral'>
         <Spring size={70} color={$darkModeThemeEnabled ? 'currentColor' : "#6DB33F"}/>
     </TryTechnology>
 
-    <TryTechnology hrefLink='https://workspaces.openshift.com/#https://github.com/che-samples/nodejs-angular/tree/devfilev2&storageType=ephemeral'>
+    <TryTechnology hrefLink='https://workspaces.openshift.com/#https://github.com/che-samples/nodejs-angular&storageType=ephemeral'>
         <Angular size={70} color={$darkModeThemeEnabled ? 'currentColor' : "#DD0031"}/>
     </TryTechnology>
 
@@ -80,7 +78,7 @@
         <PHP size={70} color={$darkModeThemeEnabled ? 'currentColor' : "#777BB4"}/>
     </TryTechnology>
 
-    <TryTechnology hrefLink='https://workspaces.openshift.com#https://github.com/che-samples/scala-sbt/tree/devfilev2&storageType=ephemeral'>
+    <TryTechnology hrefLink='https://workspaces.openshift.com#https://github.com/che-samples/scala-sbt&storageType=ephemeral'>
         <Scala size={70} color={$darkModeThemeEnabled ? 'currentColor' : "#DC322F"}/>
     </TryTechnology>
 


### PR DESCRIPTION
- Updates links to the samples located in [che-samples](https://github.com/che-samples/) to use main branch instead of devfilev2
- Updates year in the footer
- Updates Readmy since Theia is not a default editor anymore

Related issue: https://github.com/eclipse/che/issues/21926