### PR TITLE
fix: Update 'Chat' link to Eclipse Cloud Dev Tools Working Group on Slack

### DIFF
--- a/src/lib/footer/PageFooter.svelte
+++ b/src/lib/footer/PageFooter.svelte
@@ -35,7 +35,7 @@ import { variables } from '$lib/variables';
         <FooterCategory name={"Community"} />
         <nav class="list-none mb-10">
           <FooterCategoryLink name="Get involved" url="https://github.com/eclipse/che/blob/master/CONTRIBUTING.md" />
-          <FooterCategoryLink name="Chat" url="https://mattermost.eclipse.org/eclipse/channels/eclipse-che" />
+          <FooterCategoryLink name="Chat" url="https://communityinviter.com/apps/ecd-tools/join-the-community" />
           <FooterCategoryLink name="Mailing List" url="https://accounts.eclipse.org/mailing-list/che-dev" />
         </nav>
       </div>

--- a/src/lib/footer/PageFooter.svelte
+++ b/src/lib/footer/PageFooter.svelte
@@ -35,6 +35,7 @@ import { variables } from '$lib/variables';
         <FooterCategory name={"Community"} />
         <nav class="list-none mb-10">
           <FooterCategoryLink name="Get involved" url="https://github.com/eclipse/che/blob/master/CONTRIBUTING.md" />
+          <FooterCategoryLink name="Join Community Slack" url="https://communityinviter.com/apps/ecd-tools/join-the-community" />
           <FooterCategoryLink name="Chat" url="https://ecd-tools.slack.com/archives/C05SD64M85R" />
           <FooterCategoryLink name="Mailing List" url="https://accounts.eclipse.org/mailing-list/che-dev" />
         </nav>

--- a/src/lib/footer/PageFooter.svelte
+++ b/src/lib/footer/PageFooter.svelte
@@ -35,7 +35,7 @@ import { variables } from '$lib/variables';
         <FooterCategory name={"Community"} />
         <nav class="list-none mb-10">
           <FooterCategoryLink name="Get involved" url="https://github.com/eclipse/che/blob/master/CONTRIBUTING.md" />
-          <FooterCategoryLink name="Chat" url="https://communityinviter.com/apps/ecd-tools/join-the-community" />
+          <FooterCategoryLink name="Chat" url="https://ecd-tools.slack.com/archives/C05SD64M85R" />
           <FooterCategoryLink name="Mailing List" url="https://accounts.eclipse.org/mailing-list/che-dev" />
         </nav>
       </div>


### PR DESCRIPTION
[![Verify](https://www.eclipse.org/che/contribute.svg)](https://workspaces.openshift.com#https://github.com/eclipse-che/che-website/pull/94)

![website](https://github.com/eclipse-che/che-website/assets/1461122/19947d55-2016-4e5b-9dac-7759ccc94e59)

Related to https://github.com/eclipse/che/issues/22389
