### PR TITLE
feat: Add NodeJS+MongoDB sample

### DIFF
--- a/src/lib/try/TryOnline.svelte
+++ b/src/lib/try/TryOnline.svelte
@@ -11,6 +11,8 @@
 	import Angular from '@icons-pack/svelte-simple-icons/src/components/Angular.svelte';
 	import Svelte from '@icons-pack/svelte-simple-icons/src/components/Svelte.svelte';
 	import Laravel from '@icons-pack/svelte-simple-icons/src/components/Laravel.svelte';
+    import MongoDB from '@icons-pack/svelte-simple-icons/src/components/Mongodb.svelte';
+    import NodeJS from  '@icons-pack/svelte-simple-icons/src/components/NodeDotJs.svelte';
     import TryTechnology from '$lib/try/TryTechnology.svelte';
 
 	
@@ -83,6 +85,13 @@
 
     <TryTechnology hrefLink='https://workspaces.openshift.com#https://registry.devfile.io/devfiles/php-laravel/2.0.1&storageType=ephemeral'>
         <Laravel size={70} color={$darkModeThemeEnabled ? 'currentColor' : "#A8B9CC"}/>
+    </TryTechnology>
+
+    <TryTechnology hrefLink='https://workspaces.openshift.com#https://registry.devfile.io/devfiles/nodejs-mongodb/1.0.0&storageType=ephemeral'>
+        <div style="display: flex; align-items: center; gap: 4px;">
+            <NodeJS size={70} color={$darkModeThemeEnabled ? 'currentColor' : "#A8B9CC"}/>
+            <MongoDB size={70} color={$darkModeThemeEnabled ? 'currentColor' : "#A8B9CC"}/>
+        </div>
     </TryTechnology>
 
 </div>

--- a/src/lib/try/TryOnline.svelte
+++ b/src/lib/try/TryOnline.svelte
@@ -89,8 +89,8 @@
 
     <TryTechnology hrefLink='https://workspaces.openshift.com#https://registry.devfile.io/devfiles/nodejs-mongodb/1.0.0&storageType=ephemeral'>
         <div style="display: flex; align-items: center; gap: 4px;">
-            <NodeJS size={70} color={$darkModeThemeEnabled ? 'currentColor' : "#A8B9CC"}/>
-            <MongoDB size={70} color={$darkModeThemeEnabled ? 'currentColor' : "#A8B9CC"}/>
+            <MongoDB size={60} color={$darkModeThemeEnabled ? 'currentColor' : "#A8B9CC"}/>
+            <NodeJS size={60} color={$darkModeThemeEnabled ? 'currentColor' : "#A8B9CC"}/>
         </div>
     </TryTechnology>
 


### PR DESCRIPTION
Add NodeJS+MongoDB sample, the devfile is located on [registry.devfile.io](https://registry.devfile.io/devfiles/nodejs-mongodb/1.0.0)
![screenshot-gemini_google_com-2025_05_08-14_38_16](https://github.com/user-attachments/assets/0eefc915-e446-4456-97ba-c1c8bf00bbaf)

![screenshot-issues_redhat_com-2025_05_08-14_40_00](https://github.com/user-attachments/assets/22d81188-81d0-4dad-a4d8-6c1f82e9a1da)

Related issue: https://github.com/eclipse-che/che/issues/23429